### PR TITLE
Fix action space seeds for reproducibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,8 +41,10 @@ def main(_):
     env = wrap(gym.make(FLAGS.env_name))
     eval_env = wrap(gym.make(FLAGS.env_name))
 
-    env.seed(FLAGS.seed)
-    eval_env.seed(FLAGS.seed + 1)
+    for e in [eval_env, env]:
+        e.seed(FLAGS.seed)
+        e.action_space.seed(FLAGS.seed)
+        e.observation_space.seed(FLAGS.seed)
     np.random.seed(FLAGS.seed)
     random.seed(FLAGS.seed)
 


### PR DESCRIPTION
By default, `env.seed` does not set the random seed for action and observation spaces. Hence, if the code samples random actions (e.g. to collect data before training), the code will not reproduce the same results.